### PR TITLE
Add library.properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=ModuleSerial
+version=0.0.0
+author=Yuris Liepins
+maintainer=Yuris Liepins
+sentence=GSM/GPS/GPRS library for Arduino.
+paragraph=ModuleSerial provides an interface for sending GSM/GPS/GPRS AT commands to a GSM shield using SoftwareSerial. It's a lightweight alternative to the existing GSM libraries. If memory is not an issue, you should probably use GSM Library for Arduino instead. The library has been tested only on ATmega328 with a SIM808 shield.
+category=Communication
+url=https://github.com/yurisliepins/ModuleSerial
+architectures=avr
+includes=ModuleSerialCore.h


### PR DESCRIPTION
The Arduino IDE supports two library formats. The first is the 1.0 format in which the library source files are in the root library folder. The second is the 1.5 format in which the library source files are in the src subfolder of the library. Libraries in 1.5 format are required to have a library.properties file in the root library folder, which contains metadata. With this file in place, it is possible to use the popular installation technique of downloading via GitHub's Clone or download > Download ZIP, then the Arduino IDE's Sketch > Include Library > Add .ZIP library.

This library.properties file was kindly provided by @dmnc-net.

Closes https://github.com/yurisliepins/ModuleSerial/issues/2.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata