### PR TITLE
Check status of Core and GPRS

### DIFF
--- a/src/ModuleSerialCore.cpp
+++ b/src/ModuleSerialCore.cpp
@@ -24,6 +24,14 @@ int ModuleSerialCore::begin(int baudRate)
     return MODULE_READY;
 }
 
+int ModuleSerialCore::isReady()
+{
+    if (!writeCommand("AT", "OK", 2000))
+        return MODULE_FAIL;
+
+    return MODULE_READY;
+}
+
 bool ModuleSerialCore::writeCommand(const char *command, const char *expected, unsigned long timeout)
 {
     SoftwareSerial::flush();

--- a/src/ModuleSerialCore.h
+++ b/src/ModuleSerialCore.h
@@ -14,6 +14,7 @@ public:
 
     void debug(HardwareSerial *printer);
     int begin(int baudRate);
+    int isReady();
 
     bool writeCommand(const char *command, const char *expected, unsigned long timeout);
     void writeCommand(const char *command, char *output, int size, unsigned long timeout);

--- a/src/ModuleSerialGprs.cpp
+++ b/src/ModuleSerialGprs.cpp
@@ -32,6 +32,14 @@ int ModuleSerialGprs::enable(const char *apn, const char* username, const char *
     return GPRS_ENABLED;
 }
 
+int ModuleSerialGprs::isReady()
+{
+    if (!core->writeCommand("AT+CGATT=1", "OK", 2000))
+        return GPRS_FAIL;
+
+    return GPRS_ENABLED;
+}
+
 void ModuleSerialGprs::disable()
 {
     core->writeCommand("AT+CGATT=0", "+SAPBR 1: DEACT", 2000);

--- a/src/ModuleSerialGprs.h
+++ b/src/ModuleSerialGprs.h
@@ -23,6 +23,7 @@ public:
     ModuleSerialGprs(ModuleSerialCore *core);
 
     int enable(const char *apn, const char* username, const char *password);
+    int isReady();
     void disable();
 
     void openHttpConnection();


### PR DESCRIPTION
This commit adds the `isReady()` function for the Core and the GPRS. Using this you can obtain the current status.

I use this to restart the SIM808 after a crash or connection issue and to make sure that GPRS is working before sending data.